### PR TITLE
PASS1-102: Fix backwards microSD issue

### DIFF
--- a/lib/stm32lib/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd.c
+++ b/lib/stm32lib/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd.c
@@ -293,6 +293,9 @@ HAL_StatusTypeDef HAL_SD_Init(SD_HandleTypeDef *hsd)
     return HAL_ERROR;
   }
 
+  /* Initialize error code before attempting initialization so we don't inherit errors from previous init attempts */
+  hsd->ErrorCode = HAL_SD_ERROR_NONE;
+
   /* Check the parameters */
   assert_param(IS_SDMMC_ALL_INSTANCE(hsd->Instance));
   assert_param(IS_SDMMC_CLOCK_EDGE(hsd->Init.ClockEdge));


### PR DESCRIPTION
Found that `ErrorCode` in `SD_HandleTypeDef` was not reset after a failure.
Updated `HAL_SD_Init()` to reset it before attempting initialization.