### PR TITLE
PASS1-131: Fix compiling sorting for deterministic building for releases

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -234,7 +234,7 @@ DRIVERS_SRC_C = $(addprefix drivers/,\
 	)
 
 SRC_C = \
-    main.c \
+	main.c \
 	stm32_it.c \
 	usbd_conf.c \
 	usbd_desc.c \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -234,7 +234,7 @@ DRIVERS_SRC_C = $(addprefix drivers/,\
 	)
 
 SRC_C = \
-$(sort main.c \
+    main.c \
 	stm32_it.c \
 	usbd_conf.c \
 	usbd_desc.c \
@@ -301,7 +301,7 @@ $(sort main.c \
 	accel.c \
 	servo.c \
 	dac.c \
-	adc.c) \
+	adc.c \
 	$(sort $(wildcard $(BOARD_DIR)/*.c))
 
 SRC_O = \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -234,7 +234,7 @@ DRIVERS_SRC_C = $(addprefix drivers/,\
 	)
 
 SRC_C = \
-	main.c \
+$(sort main.c \
 	stm32_it.c \
 	usbd_conf.c \
 	usbd_desc.c \
@@ -301,8 +301,8 @@ SRC_C = \
 	accel.c \
 	servo.c \
 	dac.c \
-	adc.c \
-	$(wildcard $(BOARD_DIR)/*.c)
+	adc.c) \
+	$(sort $(wildcard $(BOARD_DIR)/*.c))
 
 SRC_O = \
 	$(STARTUP_FILE) \


### PR DESCRIPTION
Some files were being compiled in different orders, resulting in them being linked in different orders and making release binaries different. This is now fixed by sorting the files at blame.