### PR TITLE
TOOL-3: Setup Docker infra for Gen 1 Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ ports/stm32/secrets*
 ports/stm32/boards/Passport/bootloader/version_info.c
 
 ports/stm32/boards/Passport/bootloader/secrets*
+
+*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04 AS cross_build
+RUN apt-get update && \
+    apt-get install -y git make gcc-arm-none-eabi python3 gcc && \
+    rm -rf /var/lib/apt/lists/*
+COPY docs /workspace/passport-firmware/docs
+COPY extmod /workspace/passport-firmware/extmod
+COPY lib /workspace/passport-firmware/lib
+COPY mpy-cross /workspace/passport-firmware/mpy-cross
+COPY py /workspace/passport-firmware/py
+WORKDIR /workspace/passport-firmware/mpy-cross
+RUN make
+
+FROM ubuntu:18.04 AS cosign_build
+WORKDIR /workspace
+RUN apt-get update && \
+    apt-get install -y git make libssl-dev gcc && \
+    rm -rf /var/lib/apt/lists/*
+COPY ports/stm32/boards/Passport/tools/cosign /workspace/passport-firmware/ports/stm32/boards/Passport/tools/cosign
+COPY ports/stm32/boards/Passport/include /workspace/passport-firmware/ports/stm32/boards/Passport/include
+COPY lib /workspace/passport-firmware/lib
+COPY ports/stm32/boards/Passport/common /workspace/passport-firmware/ports/stm32/boards/Passport/common
+WORKDIR /workspace/passport-firmware/ports/stm32/boards/Passport/tools/cosign
+RUN make
+
+FROM ubuntu:18.04 AS firmware_builder
+COPY --from=cosign_build \
+    /workspace/passport-firmware/ports/stm32/boards/Passport/tools/cosign/x86/release/cosign /usr/bin/cosign
+COPY --from=cross_build \
+    /workspace/passport-firmware/mpy-cross/mpy-cross /usr/bin/mpy-cross
+RUN apt-get update && \
+    apt-get install -y make gcc-arm-none-eabi autotools-dev automake libtool python3 && \
+    rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Code specific to Passport is included in the following folders:
 
 Please see [`DEVELOPMENT.md`](https://github.com/Foundation-Devices/passport/blob/main/DEVELOPMENT.md) for information on developing for Passport.
 
+## Verifying Firmware SHA Sums
+
+To make building and verifying the firmware a simple process, there is a Dockerfile in the project that builds an image to be used to build the firmware. Using [`just`](https://github.com/casey/just), the following command can be used to verify the reproducability of the firmware. Make sure to substitute `<the sha sum>` for the SHA string to verify.
+
+```shell
+just verify-sha <the-sha-sum>
+```
+
 ## Open Source Components
 
 Passport's firmware incorporates open-source software from several third-party projects, as well as other first-party work we open-sourced.

--- a/justfile
+++ b/justfile
@@ -14,8 +14,8 @@ docker-build:
     -c 'make BOARD=Passport MPY_CROSS=/usr/bin/mpy-cross'
 
 # run the built firmware through SHA256
-sha: docker-build
-  @shasum -a 256 {{ firmware_path }} | awk '{print $1}'
+verify-sha sha: docker-build
+  echo "{{ sha }}  {{ firmware_path }}" | shasum -a 256 -c -
 
 # sign the built firmware using a private key and the cosign tool
 sign keypath filepath=firmware_path: docker-build

--- a/justfile
+++ b/justfile
@@ -15,7 +15,16 @@ docker-build:
 
 # run the built firmware through SHA256
 verify-sha sha: docker-build
-  echo "{{ sha }}  {{ firmware_path }}" | shasum -a 256 -c -
+  #!/usr/bin/env bash
+  sha=$(shasum -a 256 {{ firmware_path }} | awk '{print $1}')
+
+  echo -e "Expected SHA:\t{{ sha }}"
+  echo -e "Actual SHA:\t${sha}"
+  if [ "$sha" = "{{ sha }}" ]; then
+    echo "Hashes match!"
+  else
+    echo "ERROR: Hashes DO NOT match!"
+  fi
 
 # sign the built firmware using a private key and the cosign tool
 sign keypath version filepath=firmware_path: docker-build

--- a/justfile
+++ b/justfile
@@ -1,0 +1,16 @@
+commit_sha := `git rev-parse HEAD`
+
+# build the firmware inside docker
+docker-build:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  docker build -t foundation-devices/firmware-builder:{{ commit_sha }} .
+  docker run -it --rm -v "$PWD":/workspace \
+    -w /workspace/ports/stm32 \
+    --entrypoint bash \
+    foundation-devices/firmware-builder:{{ commit_sha }} \
+    -c 'make BOARD=Passport MPY_CROSS=/usr/bin/mpy-cross'
+
+# run the built firmware through SHA256
+sha: docker-build
+  @shasum -a 256 ports/stm32/build-Passport/firmware.bin | awk '{print $1}'

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ verify-sha sha: docker-build
   echo "{{ sha }}  {{ firmware_path }}" | shasum -a 256 -c -
 
 # sign the built firmware using a private key and the cosign tool
-sign keypath filepath=firmware_path: docker-build
+sign keypath version filepath=firmware_path: docker-build
   #!/usr/bin/env bash
   set -euxo pipefail
 
@@ -26,7 +26,7 @@ sign keypath filepath=firmware_path: docker-build
     -w /workspace \
     --entrypoint bash \
     foundation-devices/firmware-builder:{{ commit_sha }} \
-    -c "cosign -f {{ filepath }} -k {{ keypath }} -v 4.5.6"
+    -c "cosign -f {{ filepath }} -k {{ keypath }} -v {{ version }}"
 
 # clean firmware build
 clean:

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -7,7 +7,7 @@ ECHO = @echo
 RM = /bin/rm
 MKDIR = /bin/mkdir
 PYTHON = python3
-MPY_CROSS = $(MPY_DIR)/mpy-cross/mpy-cross
+MPY_CROSS ?= $(MPY_DIR)/mpy-cross/mpy-cross
 MPY_TOOL = $(PYTHON) $(MPY_DIR)/tools/mpy-tool.py
 MPY_LD = $(PYTHON) $(MPY_DIR)/tools/mpy_ld.py
 

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -63,7 +63,7 @@ endif
 
 MAKE_MANIFEST = $(PYTHON) $(TOP)/tools/makemanifest.py
 MAKE_FROZEN = $(PYTHON) $(TOP)/tools/make-frozen.py
-MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
+MPY_CROSS ?= $(TOP)/mpy-cross/mpy-cross
 MPY_TOOL = $(PYTHON) $(TOP)/tools/mpy-tool.py
 
 MPY_LIB_DIR = $(TOP)/../micropython-lib

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -100,7 +100,7 @@ $(HEADER_BUILD):
 ifneq ($(FROZEN_MANIFEST),)
 # to build frozen_content.c from a manifest
 $(BUILD)/frozen_content.c: FORCE $(BUILD)/genhdr/qstrdefs.generated.h
-	$(Q)$(MAKE_MANIFEST) -o $@ -v "MPY_DIR=$(TOP)" -v "MPY_LIB_DIR=$(MPY_LIB_DIR)" -v "PORT_DIR=$(shell pwd)" -v "BOARD_DIR=$(BOARD_DIR)" -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) $(FROZEN_MANIFEST)
+	$(Q)$(MAKE_MANIFEST) -o $@ -v "MPY_DIR=$(TOP)" -v "MPY_LIB_DIR=$(MPY_LIB_DIR)" -v "MPY_CROSS=$(MPY_CROSS)" -v "PORT_DIR=$(shell pwd)" -v "BOARD_DIR=$(BOARD_DIR)" -b "$(BUILD)" $(if $(MPY_CROSS_FLAGS),-f"$(MPY_CROSS_FLAGS)",) $(FROZEN_MANIFEST)
 
 ifneq ($(FROZEN_DIR),)
 $(error FROZEN_DIR cannot be used in conjunction with FROZEN_MANIFEST)

--- a/tools/makemanifest.py
+++ b/tools/makemanifest.py
@@ -216,7 +216,7 @@ def main():
 
     # Get paths to tools
     MAKE_FROZEN = VARS['MPY_DIR'] + '/tools/make-frozen.py'
-    MPY_CROSS = VARS['MPY_DIR'] + '/mpy-cross/mpy-cross'
+    MPY_CROSS = VARS['MPY_CROSS']
     MPY_TOOL = VARS['MPY_DIR'] + '/tools/mpy-tool.py'
 
     # Ensure mpy-cross is built


### PR DESCRIPTION
Setting up a local environment for building the firmware can be a
painful process. This wraps that process up in a Dockerfile containing
all the deps needed which is then used in the justfile to build the
firmware.