### PR TITLE
PASS1-112: Passphrase input dialog improvements

### DIFF
--- a/ports/stm32/boards/Passport/modules/actions.py
+++ b/ports/stm32/boards/Passport/modules/actions.py
@@ -1396,10 +1396,17 @@ async def enter_passphrase(menu, label, item):
     title = item.arg
     passphrase = await ux_enter_text(title, label="Enter Passphrase", max_length=MAX_PASSPHRASE_LENGTH)
 
-    # print("Chosen passphrase = {}".format(passphrase))
-
-    if not await ux_confirm('Are you sure you want to apply the passphrase:\n\n{}'.format(passphrase)):
+    # None is passed back when user chose "back"
+    if passphrase == None:
         return
+
+    # print("Chosen passphrase = {}".format(passphrase))
+    if passphrase == '':
+        if not await ux_confirm('Are you sure you want to clear the passphrase?'):
+            return
+    else:    
+        if not await ux_confirm('Are you sure you want to apply the passphrase:\n\n{}'.format(passphrase)):
+            return
 
     # Applying the passphrase takes a bit of time so show message
     dis.fullscreen("Applying Passphrase...")

--- a/ports/stm32/boards/Passport/modules/constants.py
+++ b/ports/stm32/boards/Passport/modules/constants.py
@@ -39,3 +39,6 @@ MAX_ACCOUNT_NAME_LEN = 20
 MAX_MULTISIG_NAME_LEN = 20
 
 DEFAULT_ACCOUNT_ENTRY = {'name': 'Primary', 'acct_num': 0}
+
+# Maximum amount of characters in a text entry screen
+MAX_MESSAGE_LEN = 64

--- a/ports/stm32/boards/Passport/modules/display.py
+++ b/ports/stm32/boards/Passport/modules/display.py
@@ -195,7 +195,11 @@ class Display:
     def text_input(self, x, y, msg, font=FontSmall, invert=0, cursor_pos=None, visible_spaces=False, fixed_spacing=None, cursor_shape='line'):
         from ux import word_wrap
         from utils import split_by_char_size
-        
+
+        # Maximum message size is 64 characters
+        if len(msg) >= 64:
+            msg = msg[:64]
+
         if hasattr(msg, 'readline'):
             lines = split_by_char_size(msg.getvalue(), font)
         else:
@@ -209,7 +213,8 @@ class Display:
             for line in lines:
                 self.text(x, y, line, font, invert, cursor_pos,
                           visible_spaces, fixed_spacing, cursor_shape, True)
-                y += font.leading
+                # move the y down enough to make room for 7 lines of text (hence the -2)
+                y += font.leading - 2
                 cursor_pos -= len(line)
 
     def text(self, x, y, msg, font=FontSmall, invert=0, cursor_pos=None, visible_spaces=False, fixed_spacing=None, cursor_shape='line', scrollbar_visible=False):

--- a/ports/stm32/boards/Passport/modules/display.py
+++ b/ports/stm32/boards/Passport/modules/display.py
@@ -195,10 +195,11 @@ class Display:
     def text_input(self, x, y, msg, font=FontSmall, invert=0, cursor_pos=None, visible_spaces=False, fixed_spacing=None, cursor_shape='line'):
         from ux import word_wrap
         from utils import split_by_char_size
+        from constants import MAX_MESSAGE_LEN
 
-        # Maximum message size is 64 characters
-        if len(msg) >= 64:
-            msg = msg[:64]
+        # Maximum message size is MAX_MESSAGE_LEN (64) characters
+        if len(msg) >= MAX_MESSAGE_LEN:
+            msg = msg[:MAX_MESSAGE_LEN]
 
         if hasattr(msg, 'readline'):
             lines = split_by_char_size(msg.getvalue(), font)


### PR DESCRIPTION
The passphrase is limited to 64 characters. The line spacing was reduced to make room for 7 lines. 63 capital W's will fill all 7 lines (+1 over), otherwise 64 characters usually takes about 4 lines.