### PR TITLE
PASS1-126: Passport crashes when making a microSD backup

### DIFF
--- a/ports/stm32/boards/Passport/modules/data_codecs/psbt_txn_sampler.py
+++ b/ports/stm32/boards/Passport/modules/data_codecs/psbt_txn_sampler.py
@@ -15,7 +15,7 @@ class PsbtTxnSampler(DataSampler):
     # Return True if it matches or False if not.
     @classmethod
     def sample(cls, data):
-        print('psbt sampler: data={}'.format(b2a_hex(data)))
+        # print('psbt sampler: data={}'.format(b2a_hex(data)))
         if data[0:5] == b'psbt\xff':
             return True
         if data[0:10] == b'70736274ff':        # hex-encoded

--- a/ports/stm32/boards/Passport/modules/export.py
+++ b/ports/stm32/boards/Passport/modules/export.py
@@ -40,7 +40,7 @@ def ms_has_master_xfp(xpubs):
     master_xfp = settings.get('xfp', None)
 
     for xpub in xpubs:
-        (xfp, _) = xpub
+        xfp = xpub[0]
         # print('ms_has_master_xfp: xfp={} master_xfp={}'.format(xfp, master_xfp))
         if xfp == master_xfp:
             # print('Including this one')


### PR DESCRIPTION
This issue was happening only when attempting to backup a device with a multisig configuration that contained multiple different derivation paths instead of all devices in a given configuration having the same derivation path.