### PR TITLE
Roll over the menu if scrolled past the menu boundaries

### DIFF
--- a/ports/stm32/boards/Passport/modules/login_ux.py
+++ b/ports/stm32/boards/Passport/modules/login_ux.py
@@ -8,12 +8,16 @@
 
 import version
 from display import Display, FontSmall, FontTiny
+from micropython import const
 from common import dis, pa, system, settings
 from uasyncio import sleep_ms
 from utils import UXStateMachine
 from ux import KeyInputHandler, ux_show_story, ux_show_word_list, ux_enter_pin, ux_shutdown, ux_confirm, ux_enter_text
 from pincodes import BootloaderError
 import utime
+
+# No. of PIN attempts left when the warning message will be shown
+BRICK_WARN_NUM_ATTEMPTS = const(5)
 
 # Separate PIN state machines to keep the logic cleaner in each and make it easier to change messaging in each
 
@@ -80,8 +84,12 @@ class LoginUX(UXStateMachine):
                     self.goto(self.SHOW_BRICK_MESSAGE)
                     continue
 
+                msg_brick_warning = '.'
+                if pa.attempts_left <= BRICK_WARN_NUM_ATTEMPTS:
+                  msg_brick_warning = ' until Passport is permanently disabled.'
+
                 result = await ux_show_story(
-                    'You have {} attempts remaining.'.format(pa.attempts_left),
+                    'You have {} attempts remaining{}'.format(pa.attempts_left, msg_brick_warning),
                     title="Wrong PIN",
                     left_btn='SHUTDOWN',
                     right_btn='RETRY',

--- a/ports/stm32/boards/Passport/modules/menu.py
+++ b/ports/stm32/boards/Passport/modules/menu.py
@@ -216,6 +216,9 @@ class MenuSystem:
     def down(self):
         if self.cursor < self.count-1:
             self.cursor += 1
+        else:
+          self.top()
+
         if self.cursor - self.ypos > (self.max_lines-1):
             self.ypos += 1
 
@@ -224,10 +227,16 @@ class MenuSystem:
             self.cursor -= 1
             if self.cursor < self.ypos:
                 self.ypos -= 1
+        else:
+          self.bottom()
 
     def top(self):
         self.cursor = 0
         self.ypos = 0
+
+    def bottom(self):
+      while self.cursor < self.count - 1:
+        self.down()
 
     def goto_n(self, n):
         # goto N from top of (current) screen


### PR DESCRIPTION
Scroll to bottom if clicked "up" when the topmost item is selected.
Scroll to top if clicked "down" when the downmost item is selected.

IMO it's a naturally expected behavior and helps to save some clicks in case it's needed to reach menu items closer to the opposite end of the list.

![](https://media.giphy.com/media/RXcGwPpcsuY1WbuhRI/giphy.gif)